### PR TITLE
Add Hand2World (arXiv 2602.09600)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - Menagerie [Website](https://github.com/google-deepmind/mujoco_menagerie) MuJoCo physics engines. System identification toolbox has not been released.(up to 2025.1)
 - MuJoCo Playground [Website](https://playground.mujoco.org/) [Paper](https://playground.mujoco.org/assets/playground_technical_report.pdf) Training environments in mjx. Humanoid Locomotion, Quadruped Locomotion and Manipulation (most robot arms and hand) tasks are included.
 ## papers
+- arxiv 2026, 02, Hand2World: Autoregressive Egocentric Interaction Generation via Free-Space Hand Gestures. [Paper](https://arxiv.org/abs/2602.09600). [Website](https://hand2world.github.io/).
 - arxiv 2026, 01, Cosmos Policy: Fine-Tuning Video Models for Visuomotor Control and Planning. [Paper](https://arxiv.org/abs/2601.16163). [Website](https://research.nvidia.com/labs/dir/cosmos-policy/).
 - arxiv 2025, 12, What Drives Success in Physical Planning with Joint-Embedding Predictive World Models? [Paper](https://www.arxiv.org/abs/2512.24497). [Code](https://github.com/facebookresearch/jepa-wms).
 - arxiv 2025, 12, World Models Can Leverage Human Videos for Dexterous Manipulation. [Paper](https://arxiv.org/abs/2512.13644). [Website](https://raktimgg.github.io/dexwm/).


### PR DESCRIPTION
## Summary
- Add Hand2World: Autoregressive Egocentric Interaction Generation via Free-Space Hand Gestures to the papers section
- Paper: https://arxiv.org/abs/2602.09600
- Project page: https://hand2world.github.io/